### PR TITLE
fix: devcontainers permissions on Windows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 		"dockerfile": "Dockerfile-ubuntu"
 	},
 	"onCreateCommand": "chmod +x .devcontainer/onCreateCommand.sh && ./.devcontainer/onCreateCommand.sh",
+	"remoteUser": "root",
 	// Features to add to the dev container, see https://containers.dev/feature
 	"features": {},
 


### PR DESCRIPTION
Yibo gets this error on Windows 10 22H2
```
ERROR: boost/1.79.0: Error in build() method, line 887
        self.run(full_command)
        ConanException: Error 1 while executing
[775293 ms] onCreateCommand failed with exit code 1. Skipping any further user-provided commands.
[775332 ms] Error: Command failed: /bin/sh -c chmod +x .devcontainer/onCreateCommand.sh && ./.devcontainer/onCreateCommand.sh
[775332 ms]     at fY (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:235:130)
[775332 ms]     at runMicrotasks (<anonymous>)
[775332 ms]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[775333 ms]     at async rl (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:227:4393)
[775333 ms]     at async el (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:227:3738)
[775333 ms]     at async il (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:227:2745)
[775333 ms]     at async TeA (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:612:30432)
[775333 ms]     at async PeA (/root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js:612:27664)
[775394 ms] Exit code 1
[775394 ms] Start: Run: docker rm -f 02f3da14e958f5ac342e7694eddd9f1f22dcb381674af63d53a33ff82276e8fa
[775397 ms] Command failed: node /root/.vscode-remote-containers/dist/dev-containers-cli-0.327.0/dist/spec-node/devContainersSpecCLI.js run-user-commands --container-session-data-folder /tmp/devcontainers-6c9d5dc7-f99b-4e5c-af65-512698ae1bbc1703108200595 --workspace-folder /workspaces/quetzal-CoaTL --id-label vsch.local.repository=https://github.com/Quetzal-framework/quetzal-CoaTL --id-label vsch.local.repository.volume=quetzal-CoaTL-6543d175a18dda8f2bcd1eb175a9e982510924f869315542b381993ba2369d0f --id-label vsch.local.repository.folder=quetzal-CoaTL --id-label devcontainer.config_file=/workspaces/quetzal-CoaTL/.devcontainer/devcontainer.json --container-id ac57edee18e87d76636134d23787c6affef5cced8f72d855ed1cd5fb45770eea --log-level debug --log-format json --config /workspaces/quetzal-CoaTL/.devcontainer/devcontainer.json --override-config /tmp/devcontainer-8d763103-331b-4e03-81a2-222582139ca4.json --default-user-env-probe loginInteractiveShell --skip-non-blocking-commands true --prebuild false --stop-for-personalization true --remote-env REMOTE_CONTAINERS_IPC=/tmp/vscode-remote-containers-ipc-81470aec-dcc1-49d6-b0e1-4ca9e876cbbc.sock --remote-env SSH_AUTH_SOCK=/tmp/vscode-ssh-auth-81470aec-dcc1-49d6-b0e1-4ca9e876cbbc.sock --remote-env DISPLAY=:0 --remote-env REMOTE_CONTAINERS_DISPLAY_SOCK=/tmp/.X11-unix/X0 --remote-env REMOTE_CONTAINERS=true --mount-workspace-git-root --dotfiles-target-path ~/dotfiles
[775397 ms] Exit code 1
[775712 ms] Container server terminated (code: 137, signal: null).
```
Seems like a a file permission problem.